### PR TITLE
Soporte para dinámicas no autónomas

### DIFF
--- a/docs/src/discretizers.md
+++ b/docs/src/discretizers.md
@@ -1,4 +1,4 @@
-# Discretizadores: `Discretizer `
+# Discretizadores: `Discretizer`
 
 El tipo abstracto `Discretizer` está pensado como una interfaz a las estructuras
 que permitan trabajar con una Ecuación Diferencial Ordinaria autónoma (un sistema continuo)

--- a/docs/src/discretizers.md
+++ b/docs/src/discretizers.md
@@ -19,7 +19,7 @@ Métodos a implementar | Breve descripción
 --- | ---
 `(::Discretizer)(x::AbstractArray, α::Real, t) ` | El método debe poder ser evaluado en un estado ``x``, un control ``\alpha`` y en tiempo ``t``.
 `jacobian_x(ds::Discretizer, x, α, t)` | Debe contarse con la derivada con respecto al estado.
-
+`dt(ds::Discretizer)` | ``\Delta t`` para la discretización temporal.
 Usaremos Euler progresivo como un ejemplo de cómo implementar la interfaz. 
 
 

--- a/docs/src/updaters.md
+++ b/docs/src/updaters.md
@@ -6,23 +6,33 @@ Para que funciones correctamente deben implementarse los siguientes métodos:
 
 Métodos a implementar | Breve descripción
 --- | ---
-`update!(L::KalmanUpdater, hatx, hatP, control)` | un método que permita actualizar al iterador y dejarlo listo para la siguiente iteración. Cuando se usan matrices ``M_n := M, B_n := B, F_n:= F`` contantes se puede dejar en blanco, pero debería usarse, por ejemplo, para linearlizar en torno a ``\hat{x}_n`` cuando se usa un `KalmanUpdater` no lineal.
-`forecast(updater::KalmanUpdater, hatx, hatP, control)` | Devuelve una tupla que contiene a ``\hat{x}_{n+1, n}, \hat{P}_{n+1, n}`` a partir de ``\hat{x}_{n,n}``(`hatx`), ``\hat{P}_{n,n}``(`hatP`) y un control.
+`update!(L::KalmanUpdater, hatx, hatP, control, t)` | un método que permita actualizar al iterador y dejarlo listo para la siguiente iteración. Cuando se usan matrices ``M_n := M, B_n := B, F_n:= F`` contantes se puede dejar en blanco, pero debería usarse, por ejemplo, para linearlizar en torno a ``\hat{x}_n`` cuando se usa un `KalmanUpdater` no lineal.
+`forecast(updater::KalmanUpdater, hatx, hatP, control, t)` | Devuelve una tupla que contiene a ``\hat{x}_{n+1, n}, \hat{P}_{n+1, n}`` a partir de ``\hat{x}_{n,n}``(`hatx`), ``\hat{P}_{n,n}``(`hatP`) y un control.
 
 
 ## `LinearizableUpdater`
-Un grupo importante de `KalmanUpdater`s serán los que, o bien lineales de la forma
+Un grupo importante de `KalmanUpdater`s serán los que, o bien son lineales de la forma
 
 ```math
 x_{n+1} = M_n x_n + B_n u_n + F_n N_n
 ```
 (donde ``M_n, F_n`` son matrices, ``x_n, N_n, B_n`` vectores y ``u_n`` es un control escalar), o bien, en caso de ser no lineales ``x_{n+1} = \mathcal{M}(x_n, u_n)``, pueden ser linealizados a la forma anterior.
 
-Los miembros de esta clase necesitan implementar 
+Los miembros de esta clase necesitan implementar: 
 
 Métodos a implementar | Breve descripción
 --- | ---
 `Mn`, `Bn`, `Fn`| De la linearización en el estado actual
+
+Los miembros de esta clase tienen automáticamente definidos los métodos:
+
+```julia
+forecast(updater::LinearizableUpdater, hatx, hatP, control, t)
+forecast_with_error(updater::LinearizableUpdater, hatx, hatP, control, t)
+forecast_hatP(updater::LinearizableUpdater, hatP)
+```
+!!! info "Forecast con error"
+    Para usar `EnKF`<!--TODO: agregar referencia a EnKF--> es necesario que el `KalmanUpdater` usado tenga implementado `forecast_with_error`. Esto permite hacer un paso de *forecast* e incluir error.
 
 Cuentan además con las siguientes funciones
 
@@ -33,6 +43,8 @@ KalmanFilter.dimensions
 ```@docs
 KalmanFilter.noiser
 ```
+
+los `KalmanUpdater`s de este tipo implementados son:
 
 ### SimpleLinearUpdater
 
@@ -46,7 +58,7 @@ SimpleLinearUpdater
 NLUpdater
 ```
 
-Ambas estructuras pueden ser además evaluadas en la firma `(::KalmanUpdater)(x::AbstractArray, u::Real, error)`. Por ejemplo, para el caso no lineal, `udpater(x,u,ε)` devuelve ``\mathcal{M}(x,u) + Fε``.
+Ambas estructuras pueden ser además evaluadas en la firma `(::KalmanUpdater)(x::AbstractArray, u::Real, error)`. Por ejemplo, para el caso no lineal, `nlupdater(x,u,ε)` devuelve ``\mathcal{M}(x,u) + Fε``.
 
 
 ## Otros `KalmanUpdaters` implementados 

--- a/docs/src/updaters.md
+++ b/docs/src/updaters.md
@@ -8,7 +8,7 @@ Métodos a implementar | Breve descripción
 --- | ---
 `update!(L::KalmanUpdater, hatx, hatP, control, t)` | un método que permita actualizar al iterador y dejarlo listo para la siguiente iteración. Cuando se usan matrices ``M_n := M, B_n := B, F_n:= F`` contantes se puede dejar en blanco, pero debería usarse, por ejemplo, para linearlizar en torno a ``\hat{x}_n`` cuando se usa un `KalmanUpdater` no lineal.
 `forecast(updater::KalmanUpdater, hatx, hatP, control, t)` | Devuelve una tupla que contiene a ``\hat{x}_{n+1, n}, \hat{P}_{n+1, n}`` a partir de ``\hat{x}_{n,n}``(`hatx`), ``\hat{P}_{n,n}``(`hatP`) y un control.
-
+`dt(updater::KalmanUpdater)` | ``\Delta t``
 
 ## `LinearizableUpdater`
 Un grupo importante de `KalmanUpdater`s serán los que, o bien son lineales de la forma

--- a/src/NLkalman.jl
+++ b/src/NLkalman.jl
@@ -57,7 +57,7 @@ Bn(updater::NLUpdater) = Bn(updater.linear)
 Fn(updater::NLUpdater) = Fn(updater.linear)
 Qn(updater::NLUpdater) = Qn(updater.linear)
 
-
+dt(updater::NLUpdater) = dt(updater.discretizer)
 
 #function (updater::NLUpdater)(state, control, error)
 #  updater.discretizer(state.x, control) + updater.F * error

--- a/src/NLkalman.jl
+++ b/src/NLkalman.jl
@@ -16,7 +16,7 @@ estado ``x_{n+1}`` a partir del estado ``x_{n}`` y el control ``u_n`` según
 x_{n+1} = \\mathcal{M}(x_n, u_n) + F N_n
 ```
 donde ``N_n`` es un número aleatorio (dado por una variable aleatorio normal
-``\\mathcal{N}(0,1)``) y ``\\mathcal{M}`` está dada por un `Discretizer`.
+``\\mathcal{N}(0,Q)``) y ``\\mathcal{M}`` está dada por un `Discretizer`.
 
 En todo tiempo guarda una versión linealizada del sistema, en torno a un punto 
 ``x_n, u_n, t_n`` (al construirlo se le deben dar esos valores también.)
@@ -30,11 +30,18 @@ mutable struct NLUpdater <: LinearizableUpdater
   $(TYPEDSIGNATURES)
   Constructor de un actualizador no lineal `NLUpdater`.
   # Argumentos
+  - `discretizer::Discretizer`: incorpora la información de la función no lineal 
+  a usar, así como del método de discretización. Debe tener definido `jacobian_x`.
+  - `F::Function`: función de la forma `F(x)` que devuelva una matriz cuadrada de 
+  las dimensiones de `x0`, correspondiente a la matriz de dispersión de ruido.
+  - `Q`: matriz de covarianzas del ruido (se supone Gaussiano). Debe tener las 
+  dimensiones de `x0` y ser semidefinida positiva.
+  - `x0`, `α0`, `t0`: condiciones iniciales en torno a las que se va a linealizar.
   - `integrity`: función que transforma un vector `x` para que cumple ciertas 
     restricciones de integridad (ser positivo, etc).
   """
-  function NLUpdater(discretizer::Discretizer, F, Q, x0, α, t, integrity)
-    linear = linearize_x(discretizer, x0, α, t, F, Q, integrity)
+  function NLUpdater(discretizer::Discretizer, F, Q, x0, α0, t0, integrity)
+    linear = linearize_x(discretizer, x0, α0, t0, F, Q, integrity)
     new(discretizer, F, linear, integrity)
   end
 end

--- a/src/NLkalman.jl
+++ b/src/NLkalman.jl
@@ -91,5 +91,5 @@ $(TYPEDEF)
 function linearize_x(discretizer::Discretizer, x, α, t, F, Q, integrity)
   M = jacobian_x(discretizer, x, α, t)
   B = discretizer(x, α, t) - M * x 
-  SimpleLinearUpdater(M, B, F(x), Q, integrity)
+  SimpleLinearUpdater(M, B, F(x), Q, dt(discretizer), integrity)
 end

--- a/src/NLkalman.jl
+++ b/src/NLkalman.jl
@@ -17,6 +17,9 @@ x_{n+1} = \\mathcal{M}(x_n, u_n) + F N_n
 ```
 donde ``N_n`` es un número aleatorio (dado por una variable aleatorio normal
 ``\\mathcal{N}(0,1)``) y ``\\mathcal{M}`` está dada por un `Discretizer`.
+
+En todo tiempo guarda una versión linealizada del sistema, en torno a un punto 
+``x_n, u_n, t_n`` (al construirlo se le deben dar esos valores también.)
 """
 mutable struct NLUpdater <: LinearizableUpdater
   discretizer::Discretizer
@@ -30,15 +33,15 @@ mutable struct NLUpdater <: LinearizableUpdater
   - `integrity`: función que transforma un vector `x` para que cumple ciertas 
     restricciones de integridad (ser positivo, etc).
   """
-  function NLUpdater(discretizer::Discretizer, F, Q, x0, α, integrity)
-    linear = linearize_x(discretizer, x0, α, F, Q, integrity)
+  function NLUpdater(discretizer::Discretizer, F, Q, x0, α, t, integrity)
+    linear = linearize_x(discretizer, x0, α, t, F, Q, integrity)
     new(discretizer, F, linear, integrity)
   end
 end
 
 
-function update!(updater::NLUpdater, x, P, α) #NLupdater = NonLinearUpdater(fancyM, jacobian_x)
-  linear = linearize_x(updater, x, α)
+function update!(updater::NLUpdater, x, P, α, t) #NLupdater = NonLinearUpdater(fancyM, jacobian_x)
+  linear = linearize_x(updater, x, α, t)
   updater.linear = linear
 end
 
@@ -54,18 +57,18 @@ Qn(updater::NLUpdater) = Qn(updater.linear)
 #end
 
 
-function (updater::NLUpdater)(x::AbstractArray, u::Real, noise)
-  updater.integrity(updater.discretizer(x, u) + updater.F(x) * noise)
+function (updater::NLUpdater)(x::AbstractArray, u::Real, t, noise)
+  updater.integrity(updater.discretizer(x, u, t) + updater.F(x) * noise)
 end
 
-update_inner_system(updater::NLUpdater, x::AbstractArray, u::Real) = updater(x, u, rand(noiser(updater)))
-update_aproximation(updater::NLUpdater, x::AbstractArray, u::Real) = updater(x, u, zeros(dimensions(updater)))
+update_inner_system(updater::NLUpdater, x::AbstractArray, u::Real, t) = updater(x, u, t, rand(noiser(updater)))
+update_aproximation(updater::NLUpdater, x::AbstractArray, u::Real, t) = updater(x, u, t, zeros(dimensions(updater)))
 
 #### podría hacer algo que retorne un linear updater...
 
-function linearize_x(NLup::NLUpdater, x, α)
+function linearize_x(NLup::NLUpdater, x, α, t)
   discretizer = NLup.discretizer
-  linearize_x(discretizer, x, α, NLup.F, Qn(NLup), NLup.integrity)
+  linearize_x(discretizer, x, α, t, NLup.F, Qn(NLup), NLup.integrity)
 end
 
 """
@@ -78,8 +81,8 @@ $(TYPEDEF)
 - `Q`: matriz de covarianza del ruido 
 - `integrity`: función de `x`, que conserva el valor dentro de un dominio.
 """
-function linearize_x(discretizer::Discretizer, x, α, F, Q, integrity)
-  M = jacobian_x(discretizer, x, α)
-  B = discretizer(x, α) - M * x 
+function linearize_x(discretizer::Discretizer, x, α, t, F, Q, integrity)
+  M = jacobian_x(discretizer, x, α, t)
+  B = discretizer(x, α, t) - M * x 
   SimpleLinearUpdater(M, B, F(x), Q, integrity)
 end

--- a/src/discretizers.jl
+++ b/src/discretizers.jl
@@ -5,6 +5,7 @@ abstract type Discretizer end
 
 function (::Discretizer)(x,α,t) error("No se ha definido un método para este discretizador.") end
 function jacobian_x(ds::Discretizer, x, α, t) error("No se ha definido un método para este discretizador.")  end
+dt(ds::Discretizer) = ds.dt
 
 """
 $(TYPEDEF)

--- a/src/kalman.jl
+++ b/src/kalman.jl
@@ -22,6 +22,8 @@ function next_iteration!(iterator::KalmanIterator, control)
   # prepare structures for next iteration 
   update_updater!(iterator)
 
+  advance_counter!(iterator)
+
   yₙ₊₁
 end
 
@@ -95,6 +97,8 @@ mutable struct LinearKalmanIterator{T} <: KalmanIterator
     new{T}(n, 1., system, hatX, next_hatX, updater, observer, noiser, alpha)
   end
 end
+
+tn(iterator) = iterator.n * dt(iterator.updater)
 
 function update_inner_state!(iterator::LinearKalmanIterator, control)
   update_real_state!(iterator.system, iterator.updater, control)
@@ -172,11 +176,11 @@ function observe_observed_system(iterator::LinearKalmanIterator)
 end
 
 function update_updater!(iterator::LinearKalmanIterator)
-  update!(iterator.updater, hatx(iterator), hatP(iterator), un(iterator))
+  update!(iterator.updater, hatx(iterator), hatP(iterator), un(iterator), tn(iterator))
 end
 
 function forecast(iterator::LinearKalmanIterator, control)
-  forecast(iterator.updater, hatx(iterator), hatP(iterator), control)
+  forecast(iterator.updater, hatx(iterator), hatP(iterator), control, tn(iterator))
 end
 
 function forecast_observed_state!(iterator::LinearKalmanIterator, control)

--- a/src/updaters.jl
+++ b/src/updaters.jl
@@ -93,7 +93,7 @@ struct SimpleLinearUpdater{T} <: LinearizableUpdater
   F::AbstractMatrix{T}
   """Matriz ``Q`` de covarianzas del error"""
   Q::AbstractMatrix{T}
-  """``\Delta t``"""
+  """``\\Delta t``"""
   dt
   """Función que corrige `x` para dejarlo dentro de un dominio."""
   integrity

--- a/src/updaters.jl
+++ b/src/updaters.jl
@@ -5,10 +5,10 @@ using Distributions, Random, ComponentArrays
 
 # Interfaz que debe ser definida por las estructuras tipo `KalmanUpdater`.
 abstract type KalmanUpdater end
-function update!(L::KalmanUpdater, hatx, hatP, control) error("Updating method not defined") end
+function update!(L::KalmanUpdater, hatx, hatP, control, t) error("Updating method not defined") end
 #function (updater::KalmanUpdater)(x::AbstractArray, u::Real, noise) error("Evaluation method not defined") end
-function update_inner_system(updater::KalmanUpdater, x::AbstractArray, u::Real) error("Implement update_inner_system") end
-function update_aproximation(updater::KalmanUpdater, x::AbstractArray, u::Real) error("Implement update_aproximation") end
+function update_inner_system(updater::KalmanUpdater, x::AbstractArray, u::Real, t) error("Implement update_inner_system") end
+function update_aproximation(updater::KalmanUpdater, x::AbstractArray, u::Real, t) error("Implement update_aproximation") end
 
 abstract type LinearizableUpdater <: KalmanUpdater end
 
@@ -19,8 +19,8 @@ function Qn(::LinearizableUpdater) error("Por favor defina Qn para LinearizableU
 
 ################################################################################
 
-function (updater::KalmanUpdater)(state::StochasticState, error)
-  updater(state.x, state.u, error)
+function (updater::KalmanUpdater)(state::StochasticState, t, error)
+  updater(state.x, state.u, t, error)
 end
 #=================================================================
 Las funciones que siguen solo sirven para el caso en que updater 

--- a/src/updaters.jl
+++ b/src/updaters.jl
@@ -97,15 +97,15 @@ struct SimpleLinearUpdater{T} <: LinearizableUpdater
   integrity
 end
 
-function (updater::SimpleLinearUpdater)(x::AbstractArray, u::Real, noise)
+function (updater::SimpleLinearUpdater)(x::AbstractArray, u::Real, t, noise)
   updater.integrity(updater.M * x + updater.B * u + updater.F * noise)
 end
 
-update_inner_system(updater::SimpleLinearUpdater, x::AbstractArray, u::Real) = updater(x, u, rand(noiser(updater)))
-update_aproximation(updater::SimpleLinearUpdater, x::AbstractArray, u::Real) = updater(x, u, zeros(dimensions(updater)))
+update_inner_system(updater::SimpleLinearUpdater, x::AbstractArray, u::Real, t) = updater(x, u, t, rand(noiser(updater)))
+update_aproximation(updater::SimpleLinearUpdater, x::AbstractArray, u::Real, t) = updater(x, u, t, zeros(dimensions(updater)))
 
 
-function update!(L::SimpleLinearUpdater, hatx, hatP, control) end # no necesita actualizarse
+function update!(L::SimpleLinearUpdater, hatx, hatP, control, t) end # no necesita actualizarse
 
 Mn(updater::SimpleLinearUpdater) = updater.M
 Bn(updater::SimpleLinearUpdater) = updater.B

--- a/src/updaters.jl
+++ b/src/updaters.jl
@@ -93,9 +93,13 @@ struct SimpleLinearUpdater{T} <: LinearizableUpdater
   F::AbstractMatrix{T}
   """Matriz ``Q`` de covarianzas del error"""
   Q::AbstractMatrix{T}
+  """``\Delta t``"""
+  dt
   """Función que corrige `x` para dejarlo dentro de un dominio."""
   integrity
 end
+
+dt(updater::SimpleLinearUpdater) = updater.dt 
 
 function (updater::SimpleLinearUpdater)(x::AbstractArray, u::Real, t, noise)
   updater.integrity(updater.M * x + updater.B * u + updater.F * noise)

--- a/src/updaters.jl
+++ b/src/updaters.jl
@@ -30,16 +30,16 @@ De no ser así, será obligatorio definir
 `forecast(updater::KalmanUpdater, hatx, hatP, control)` 
 =================================================================#
 
-function forecast(updater::LinearizableUpdater, hatx, hatP, control)
+function forecast(updater::LinearizableUpdater, hatx, hatP, control, t)
   hatPnp1 = forecast_hatP(updater, hatP)
-  hatxnp1 = update_aproximation(updater, hatx, control)
+  hatxnp1 = update_aproximation(updater, hatx, control, t)
   ComponentArray(x = hatxnp1, P = hatPnp1)
 end
 # esta funcion es para EnKF, que necesita agregarle ruido a las aproximaciones
 # a diferencia de los demas metodos
-function forecast_with_error(updater::LinearizableUpdater, hatx, hatP, control)
+function forecast_with_error(updater::LinearizableUpdater, hatx, hatP, control, t)
   hatPnp1 = forecast_hatP(updater, hatP)
-  hatxnp1 = update_inner_system(updater, hatx, control)
+  hatxnp1 = update_inner_system(updater, hatx, control, t)
   ComponentArray(x = hatxnp1, P = hatPnp1)
 end
 


### PR DESCRIPTION
Ahora es posible usar dinámicas (modelos de estados) no autónomas (con dependencia explícita del tiempo, no solo de los estados y controles). Esto debería permitir, por ejemplo, usar un modelo que incorpora datos reales en la dinámica (series de tiempo).